### PR TITLE
Rewrite README with fork origin, attribution and licensing

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,212 @@
+<!-- markdownlint-disable MD033 -->
+**Español** · [English](README.md)
+
+# Freedom ATE — tema para Omeka S
+
+Tema de Omeka S para **ATE Educación** (Área de Tecnología Educativa, Consejería de
+Educación del Gobierno de Canarias), usado en un **servicio de repositorio de recursos
+digitales para centros educativos públicos**.
+
+Es un fork del tema [Freedom](https://github.com/omeka-s-themes/freedom), adaptado a las
+necesidades de ese servicio: identidad institucional, herramientas de edición para el
+profesorado, una experiencia de navegación y búsqueda más rica, y localización al español.
+
+<a href="https://ateeducacion.github.io/omeka-s-playground/?blueprint=https%3A%2F%2Fraw.githubusercontent.com%2Fateeducacion%2Fomeka-s-theme-freedom-ate%2Frefs%2Fheads%2Fmaster%2Fblueprint.json">
+  <img src="https://raw.githubusercontent.com/ateeducacion/omeka-s-theme-freedom-ate/refs/heads/master/.github/assets/playground-preview-button.svg" alt="Probar Freedom ATE en el navegador" width="224">
+</a><br>
+<small><a href="https://ateeducacion.github.io/omeka-s-playground/?blueprint=https%3A%2F%2Fraw.githubusercontent.com%2Fateeducacion%2Fomeka-s-theme-freedom-ate%2Frefs%2Fheads%2Fmaster%2Fblueprint.json">Probar en el navegador</a></small>
+
+---
+
+## Origen y atribución
+
+Este tema **no** es una obra original. Desciende del tema Freedom para Omeka S, y el
+historial de este repositorio empieza con los commits de ese mismo tema.
+
+| | |
+|---|---|
+| **Tema original** | [Freedom](https://github.com/omeka-s-themes/freedom), desarrollado también en [nelsonamaya82/theme-freedom](https://github.com/nelsonamaya82/theme-freedom) |
+| **Autor original** | Nelson Amaya — [Out of the Bugs](https://www.outofthebugs.com) |
+| **Con aportaciones de** | El equipo de Omeka en [RRCHNM](https://rrchnm.org) (Roy Rosenzweig Center for History and New Media) |
+| **Plataforma** | [Omeka S](https://omeka.org/s/), de RRCHNM |
+| **Este fork** | ATE Educación, Gobierno de Canarias |
+
+El mérito del diseño y de la gran mayoría del código corresponde al proyecto original.
+Los problemas relativos a este fork deben reportarse aquí, no a sus autores.
+
+### Cambios introducidos en este fork
+
+La GPL pide que las versiones modificadas indiquen de forma visible que lo han sido, así
+que estas son las diferencias sustantivas respecto al original:
+
+- **Identidad institucional** — logotipo institucional configurable en la barra superior
+  de la cabecera, y enlace opcional a la página de inicio del servicio.
+- **Herramientas de edición** — acciones de editar, añadir medios y eliminar para las
+  personas con permisos de edición en el sitio actual, con modal de confirmación (helper
+  `CanEditInCurrentSite`).
+- **Etiquetas de recurso** — etiquetas de color según el tipo y la clase del recurso, más
+  una etiqueta de antigüedad de publicación basada en `dcterms:date`.
+- **Navegación y búsqueda** — diseños de cuadrícula y lista con conmutador, opciones de
+  truncado del cuerpo, y plantillas para el módulo
+  [AdvancedSearch](https://gitlab.com/Daniel-KM/Omeka-S-module-AdvancedSearch).
+- **Localización al español** — traducción completa (`language/es.po`).
+- **Refuerzo de seguridad** — escapado de salida y validación de los ajustes del tema que
+  se usan en bloques `<style>` y en atributos `href`.
+
+El registro completo está en el historial de commits.
+
+---
+
+## Licencia
+
+Este tema se distribuye bajo la **Licencia Pública General de GNU, versión 3.0**. El texto
+completo está en [`LICENSE`](LICENSE).
+
+Tanto el fichero `LICENSE` como las cabeceras del código proceden del proyecto original, y
+conviene leerlos juntos: la cabecera de `asset/sass/style.scss` indica *"GNU General Public
+License v2 or later"*, mientras que la licencia incluida es la v3. La cláusula *"or later"*
+es lo que hace coherente ambas cosas: permite distribuir bajo la v3, que es lo que hace el
+fichero `LICENSE` y lo que declara `package.json`.
+
+### Qué implica si reutilizas este tema
+
+La GPL es una licencia copyleft, así que redistribuirlo —modificado o no— conlleva
+obligaciones:
+
+1. **Conservar la licencia y los avisos de copyright.** No elimines `LICENSE` ni las
+   cabeceras de los ficheros Sass.
+2. **Distribuir bajo la misma licencia.** Las obras derivadas también deben ser GPL-3.0.
+3. **Declarar los cambios**, como hace este README más arriba.
+4. **Facilitar el código fuente.** Si distribuyes el tema, quien lo reciba debe poder
+   obtener el código correspondiente, incluidas tus modificaciones.
+
+Atribuir la autoría original no es aquí una mera cortesía: conservar los avisos es una
+condición de la licencia.
+
+### Recursos de terceros
+
+- **Tipografías** — Open Sans y Noto Serif se cargan desde Google Fonts en tiempo de
+  ejecución, y Material Symbols mediante un `@import` de Sass. No están incluidas en este
+  repositorio. Ten en cuenta que esto genera una petición a Google en cada carga de
+  página, lo que puede ser relevante para vuestra evaluación de privacidad; la mitigación
+  es alojarlas localmente.
+- **Iconos** — la tipografía de iconos de Omeka S la aporta la plataforma, no este tema.
+- **Los logotipos institucionales** los suben las personas administradoras desde los
+  ajustes del tema y no forman parte de este repositorio. Suelen estar sujetos a sus
+  propias normas de uso, independientes de la licencia de este tema.
+
+---
+
+## Instalación
+
+Para un uso normal, sigue las [instrucciones de instalación de temas del manual de Omeka
+S](https://omeka.org/s/docs/user-manual/sites/site_theme/#installing-themes).
+
+Requiere Omeka S `^4.1.0`.
+
+Para trabajar sobre el Sass del tema necesitarás [Node.js](https://nodejs.org/en/). Desde
+el directorio del tema:
+
+```bash
+npm install
+```
+
+---
+
+## Ajustes del tema
+
+Se configuran por sitio en *Sitios → [sitio] → Tema*.
+
+### General
+- **Color primario / secundario / de acento** — de ellos se derivan las propiedades
+  personalizadas CSS sobre las que se construye la hoja de estilos. Solo se aceptan
+  valores hexadecimales.
+
+### Cabecera
+- **Menú de cabecera** — muestra el menú de navegación; si se desactiva, solo aparecen el
+  logotipo y el nombre del sitio.
+- **Diseño de cabecera** — en línea, o logotipo y menú centrados.
+- **Profundidad de la navegación** — número máximo de niveles del menú; 0 o vacío los
+  muestra todos.
+- **Logotipo** — el logotipo del sitio, junto al nombre.
+- **Logotipo institucional** — se muestra arriba a la izquierda de la cabecera.
+- **Enlace a la página de inicio** — logotipo opcional que enlaza a la página de inicio del
+  servicio. Requiere logotipo **y** URL; si falta cualquiera de los dos, el enlace no se
+  muestra.
+
+### Banner
+Imagen, titular, descripción, posición del contenido, anchura, altura, altura en móvil, y
+posición vertical y horizontal de la imagen dentro de su contenedor.
+
+### Pie de página
+Logotipo, descripción del sitio, menú y profundidad del menú, contenido libre y aviso de
+copyright.
+
+### Redes sociales
+URLs de Facebook, Twitter, LinkedIn, Instagram, YouTube y Mastodon. Solo se aceptan URLs
+`http(s)`; cualquier otra cosa no se muestra.
+
+### Ajustes de imagen
+Borde decorativo para medios y/o recursos.
+
+### Etiquetas de recurso
+Muestra etiquetas según el tipo y/o la clase del recurso.
+
+### Ajustes de navegación
+Diseño de las páginas de listado (cuadrícula, lista, o cualquiera de las dos con
+conmutador para quien visita) y truncado del cuerpo.
+
+---
+
+## Desarrollo
+
+Comandos a ejecutar desde la raíz del tema:
+
+| Comando | Función |
+|---|---|
+| `npm run start` | Vigila los ficheros Sass y recompila al guardar |
+| `npx gulp css` | Compilación puntual de Sass a CSS |
+| `npm run compile-translations` | Compila los ficheros `.po` a `.mo` |
+
+> [!IMPORTANT]
+> **`asset/css/style.css` es un fichero generado, pero está commiteado.** Después de
+> modificar cualquier `.scss` hay que ejecutar la compilación y commitear el resultado; de
+> lo contrario el repositorio publica una hoja de estilos que no se corresponde con sus
+> propias fuentes. Ya ha ocurrido antes.
+
+### Traducciones
+
+Las cadenas están en `language/`. `template.pot` es la plantilla de extracción, `es.po` el
+catálogo en español, y `es.mo` la versión compilada que Omeka carga realmente: hay que
+regenerarla tras editar `es.po`.
+
+### Sobrescritura de vistas
+
+Las plantillas de `view/` sobrescriben las de Omeka S y las de los módulos. Omeka resuelve
+los view scripts por ruta y el tema gana sobre el módulo, así que no hay que registrar nada
+en `config/`. En `view/search/` están las sobrescrituras del módulo AdvancedSearch: copia
+el partial original del módulo como punto de partida y edítalo aquí, sin tocar el módulo.
+
+Cuando varias *search pages* necesiten diseños distintos, dale a cada una su propio nombre
+de partial y apunta cada página al suyo; sobrescribir el partial canónico rompe las demás.
+
+Si un cambio no aparece, vacía la caché de Omeka (`files/cache/`) y el OPcache de PHP antes
+de buscar otras causas.
+
+### Estructura del Sass
+
+```bash
+sass
+    ├── abstracts        # variables (breakpoints, colores, layout, tipografía) y mixins
+    ├── base             # elementos, layout y tipografía
+    ├── components       # cabecera, pie, banner, navegación, bloques, recursos, facetas…
+    ├── generic          # box-sizing, normalize
+    └── utilities        # accesibilidad, alineaciones, clearfix
+```
+
+### Clases de utilidad
+
+Clases predefinidas que pueden combinarse en cualquier elemento:
+
+`inline` · `alignleft` · `alignright` · `aligncenter` · `alignfull` · `alignwide` ·
+`alignnarrow` · `textleft` · `textright` · `textcenter` · `clearfix` · `screen-reader-text`

--- a/README.md
+++ b/README.md
@@ -1,176 +1,200 @@
-# This is an adaptation of Freedom S Theme for using in ATE
+# Freedom ATE — Omeka S theme
+
+An Omeka S theme for **ATE Educación** (Área de Tecnología Educativa, Consejería de
+Educación del Gobierno de Canarias), used to run a **digital resource repository service
+for public schools**.
+
+It is a fork of the [Freedom](https://github.com/omeka-s-themes/freedom) theme, adapted to
+the needs of that service: institutional branding, editor tooling for teaching staff, a
+richer browse and search experience, and Spanish localisation.
 
 <a href="https://ateeducacion.github.io/omeka-s-playground/?blueprint=https%3A%2F%2Fraw.githubusercontent.com%2Fateeducacion%2Fomeka-s-theme-freedom-ate%2Frefs%2Fheads%2Fmaster%2Fblueprint.json">
   <img src="https://raw.githubusercontent.com/ateeducacion/omeka-s-theme-freedom-ate/refs/heads/master/.github/assets/playground-preview-button.svg" alt="Try Freedom ATE in your browser" width="224">
 </a><br>
 <small><a href="https://ateeducacion.github.io/omeka-s-playground/?blueprint=https%3A%2F%2Fraw.githubusercontent.com%2Fateeducacion%2Fomeka-s-theme-freedom-ate%2Frefs%2Fheads%2Fmaster%2Fblueprint.json">Try in your browser</a></small>
 
-This is an Omeka S theme that offers some custom options and a clean design.
-![Freedom Theme](https://github.com/omeka-s-themes/freedom/blob/master/theme.jpg?raw=true)
+---
+
+## Origin and attribution
+
+This theme is **not** an original work. It descends from the Freedom theme for Omeka S,
+and this repository's history begins with that theme's own commits.
+
+| | |
+|---|---|
+| **Upstream theme** | [Freedom](https://github.com/omeka-s-themes/freedom), also developed at [nelsonamaya82/theme-freedom](https://github.com/nelsonamaya82/theme-freedom) |
+| **Original author** | Nelson Amaya — [Out of the Bugs](https://www.outofthebugs.com) |
+| **Also contributed by** | The Omeka team at [RRCHNM](https://rrchnm.org) (Roy Rosenzweig Center for History and New Media) |
+| **Platform** | [Omeka S](https://omeka.org/s/), by RRCHNM |
+| **This fork** | ATE Educación, Gobierno de Canarias |
+
+Credit for the design and the great majority of the code belongs upstream. Please report
+issues with this fork here, not to the upstream authors.
+
+### Changes made in this fork
+
+The GPL asks that modified versions carry prominent notice of their modification, so the
+substantive divergences from upstream are listed here:
+
+- **Institutional branding** — configurable institutional logo in the header top bar, and
+  an optional link to the landing page of the installation.
+- **Editor tooling** — inline edit / add media / delete actions for users with editing
+  rights on the current site, with a confirmation modal (`CanEditInCurrentSite` helper).
+- **Resource tags** — colour-coded tags derived from resource type and class, plus a
+  publication-age badge based on `dcterms:date`.
+- **Browse and search** — grid/list layouts with a toggle, body property truncation
+  options, and templates for the [AdvancedSearch](https://gitlab.com/Daniel-KM/Omeka-S-module-AdvancedSearch)
+  module.
+- **Spanish localisation** — full `es` translation (`language/es.po`).
+- **Security hardening** — output escaping and validation of theme settings used in
+  `<style>` blocks and `href` attributes.
+
+See the commit history for the complete record.
+
+---
+
+## Licensing
+
+This theme is distributed under the **GNU General Public License v3.0**. The full text is
+in [`LICENSE`](LICENSE).
+
+Both the `LICENSE` file and the source headers come from upstream, and they are worth
+reading together: the Sass header in `asset/sass/style.scss` states *"GNU General Public
+License v2 or later"*, while the bundled licence text is v3. The "or later" clause is what
+makes this coherent — it permits distribution under v3, which is what the `LICENSE` file
+does and what `package.json` declares.
+
+### What this means if you reuse this theme
+
+The GPL is copyleft, so redistributing it — modified or not — carries obligations:
+
+1. **Keep the licence and copyright notices.** Do not strip `LICENSE` or the headers in
+   the Sass sources.
+2. **Distribute under the same licence.** Derivative works must also be GPL-3.0.
+3. **State your changes**, as this README does above.
+4. **Provide the source.** If you distribute the theme, recipients must be able to get the
+   corresponding source, including your modifications.
+
+Attribution to the original authors is not merely courteous here — preserving the notices
+is a licence condition.
+
+### Third-party assets
+
+- **Fonts** — Open Sans and Noto Serif are loaded from Google Fonts at runtime, and
+  Material Symbols via a Sass `@import`. They are not bundled in this repository. Note
+  that this makes a request to Google on every page load, which may matter for your
+  privacy assessment; self-hosting them is the mitigation.
+- **Icons** — the Omeka S icon font is provided by the platform, not by this theme.
+- **Institutional logos** are uploaded by administrators through the theme settings and
+  are not part of this repository. They are typically subject to their own usage rules,
+  which are independent of this theme's licence.
+
+---
 
 ## Installation
 
-For basic out-of-the-box use of the theme, follow the [Omeka S User Manual instructions for installing themes](https://omeka.org/s/docs/user-manual/sites/site_theme/#installing-themes).
+For normal use, follow the [Omeka S User Manual instructions for installing
+themes](https://omeka.org/s/docs/user-manual/sites/site_theme/#installing-themes).
 
-For more advanced use, such as customizing the theme with Sass, you'll need to install the tools with [NodeJS](https://nodejs.org/en/) (0.12 or greater). Navigate to your theme directory and run `npm install`.
+Requires Omeka S `^4.1.0`.
+
+To work on the theme's Sass you will need [Node.js](https://nodejs.org/en/). From the
+theme directory:
+
+```bash
+npm install
+```
+
+---
 
 ## Theme settings
 
-### Theme's Primary Color
-The color to be used as the theme's primary color. The default value is #e77f11 (RGB 231, 127, 17).
+Configured per site under *Sites → [site] → Theme*.
 
-### Header Layout
-- Inline logo and menu
-- Centered logo and menu
+### General
+- **Primary / Secondary / Accent colour** — used to derive the CSS custom properties the
+  stylesheet is built on. Only hexadecimal values are accepted.
 
-### Top Navigation Depth
-Maximum number of levels to show in the site's top navigation bar. Set to 0 to show all levels.
-
-### Logo
-A custom logo (SVG, JPG, PNG)
+### Header
+- **Header Menu** — show the navigation menu; if off, only the logo and site name appear.
+- **Header Layout** — inline, or centred logo and menu.
+- **Top Navigation Depth** — maximum menu levels; 0 or empty shows all.
+- **Logo** — the site logo, next to the site name.
+- **Institutional Logo** — shown at the top left of the header.
+- **Landing Page Link** — optional logo linking to the service landing page. Requires both
+  a logo and a URL; if either is missing the link is not rendered.
 
 ### Banner
-- Banner image
-- Heading
-- Description
-- Content position
-- Banner width
-- Banner height
-- Banner height for mobile devices
-- Banner image vertical position within the wrapper
-- Banner image horizontal position within the wrapper
+Image, heading, description, content position, width, height, height on mobile, and the
+image's vertical and horizontal position within its wrapper.
 
 ### Footer
-- Footer Logo
-- Footer Site description
-- Footer Menu
-- Footer Menu Depth
-- Footer Content
-- Footer Copyright
+Logo, site description, menu and menu depth, free content, and copyright notice.
 
 ### Social Media
-- Facebook
-- Twitter
-- LinkedIn
-- Instagram
-- Youtube
-- Mastodon
+Facebook, Twitter, LinkedIn, Instagram, YouTube and Mastodon URLs. Only `http(s)` URLs are
+accepted; anything else is not rendered.
 
 ### Image Settings
-- Decorative border for Media and/or Assets
+Decorative border for media and/or assets.
 
 ### Resource Tags
-- Show tags based on Resource Type or Class
+Show tags derived from resource type and/or resource class.
 
 ### Browse Settings
-- Layout for Browse Pages
-- Truncate Body Property
+Layout for browse pages (grid, list, or either with a visitor toggle) and body property
+truncation.
 
-## Customizing the Theme
+---
 
-If you want to customize the site with your own CSS, the [CSS Editor](https://omeka.org/s/modules/CSSEditor/) module allows site administrators to write style overrides.
+## Development
 
-For advanced CSS and Sass users, this theme includes variables and mixins for managing and extending many styles.
+Run from the theme's root directory:
 
-### Sass Tasks
+| Command | Purpose |
+|---|---|
+| `npm run start` | Watch Sass files and recompile on change |
+| `npx gulp css` | One-off compile of Sass to CSS |
+| `npm run compile-translations` | Compile `.po` files to `.mo` |
 
-Run these commands within the theme's root directory.
+> [!IMPORTANT]
+> **`asset/css/style.css` is generated but committed.** After changing any `.scss` file you
+> must run the build and commit the result, otherwise the repository ships a stylesheet
+> that does not match its own sources. This has drifted before.
 
-* **npm run start**: While this task runs, it watches for changes to sass files and recompiles the CSS.
-* **gulp css**: This is the one-off task for compiling the current Sass/CSS.
-* **gulp css:watch**: This task watches for changes in the Sass, then compiles the CSS.
+### Translations
 
-### Sass File Structure
+Strings live in `language/`. `template.pot` is the extraction template, `es.po` the Spanish
+catalogue, and `es.mo` the compiled form that Omeka actually loads — regenerate it after
+editing `es.po`.
+
+### View overrides
+
+Templates in `view/` override those of Omeka S and of modules; Omeka resolves view scripts
+by path and the theme wins over the module, so nothing needs registering in `config/`.
+`view/search/` holds overrides for the AdvancedSearch module — copy the module's original
+partial as a starting point and edit it here rather than modifying the module.
+
+Where several search pages need different layouts, give each its own partial name and
+point each search page at its own; overwriting the canonical partial breaks the others.
+
+If a change does not appear, clear Omeka's `files/cache/` and the PHP OPcache before
+looking for other causes.
+
+### Sass structure
 
 ```bash
 sass
-    ├── abstracts
-    │   ├── mixins
-    │   └── variables
-    │       ├── breakpoints
-    │       ├── colors
-    │       ├── layout
-    │       └── typography
-    ├── base
-    │   ├── elements
-    │   │   ├── body
-    │   │   ├── buttons
-    │   │   ├── caption
-    │   │   ├── fields
-    │   │   ├── hr
-    │   │   ├── icons
-    │   │   ├── language-tag
-    │   │   ├── links
-    │   │   ├── lists
-    │   │   ├── media
-    │   │   ├── resource-description
-    │   │   ├── resource-tag
-    │   │   ├── tables
-    │   │   ├── titles
-    │   │   └── tooltip
-    │   ├── layout
-    │   │   ├── layout
-    │   │   └── regions
-    │   └── typography
-    │       ├── copy
-    │       ├── headings
-    │       └── typography
-    ├── components
-    │   ├── accordion
-    │   ├── advanced-search
-    │   ├── annotation
-    │   ├── banner
-    │   ├── blocks
-    │   │   ├── assets
-    │   │   ├── browse-preview
-    │   │   ├── carousel
-    │   │   ├── collecting
-    │   │   ├── item-showcase
-    │   │   ├── item-with-metadata
-    │   │   ├── list-of-sites
-    │   │   ├── media-embed
-    │   │   ├── table-of-contents
-    │   │   └── timeline
-    │   ├── breadcrumbs
-    │   ├── facets
-    │   ├── footer
-    │   ├── header
-    │   ├── linked-resources
-    │   ├── metadata
-    │   ├── navigation
-    │   ├── pagination
-    │   ├── resources
-    │   │   ├── browse-controls
-    │   │   ├── resource-grid
-    │   │   ├── resource-list
-    │   ├── search-results
-    │   ├── uri-dereferencer
-    │   └── user-bar
-    ├── generic
-    │   ├── box-sizing
-    │   └── normalize
-    └── utilities
-        ├── accessibility
-        ├── alignments
-        └── clearfix
+    ├── abstracts        # variables (breakpoints, colors, layout, typography) and mixins
+    ├── base             # elements, layout and typography
+    ├── components       # header, footer, banner, navigation, blocks, resources, facets…
+    ├── generic          # box-sizing, normalize
+    └── utilities        # accessibility, alignments, clearfix
 ```
 
-## Utility classes
-Freedom S offers a set of predefined utiliy classes that will help you to add styles to certain elements by just assigning them these classes.
+### Utility classes
 
-You can even combine multiple utility classes.
+Predefined classes that can be combined on any element:
 
-- `inline`
-- `alignleft`
-- `alignright`
-- `aligncenter`
-- `alignfull`
-- `alignwide`
-- `alignnarrow`
-- `textleft`
-- `textright`
-- `textcenter`
-- `clearfix`
-- `screen-reader-text`
-
-
+`inline` · `alignleft` · `alignright` · `aligncenter` · `alignfull` · `alignwide` ·
+`alignnarrow` · `textleft` · `textright` · `textcenter` · `clearfix` · `screen-reader-text`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD033 -->
+**English** · [Español](README.es.md)
+
 # Freedom ATE — Omeka S theme
 
 An Omeka S theme for **ATE Educación** (Área de Tecnología Educativa, Consejería de


### PR DESCRIPTION
The README opened with *"This is an adaptation of Freedom S Theme for using in ATE"*
and then reproduced upstream's documentation verbatim — without saying who wrote
the original, under what licence it is distributed, or what this fork changes.

## What this adds

**Origin and attribution** — credits Nelson Amaya ([Out of the Bugs](https://www.outofthebugs.com)),
the upstream [Freedom](https://github.com/omeka-s-themes/freedom) theme, and the Omeka
team at RRCHNM. This repository's history literally begins with upstream's commits
(150 of ~220 are Nelson Amaya's), so the README now says so plainly.

**Licensing** — GPL-3.0 terms and what they require of anyone redistributing: keep the
notices, same licence for derivatives, state changes, provide source. Also covers
third-party assets (Google Fonts loaded at runtime, Omeka's icon font, institutional
logos that are not in the repo and carry their own usage rules).

**Changes made in this fork** — the GPL asks modified versions to carry prominent notice
of modification, which the previous README did not do.

**Purpose** — a digital resource repository service for public schools, run by ATE
Educación.

## Also corrected

The settings documentation had drifted from `config/theme.ini`. It was missing the
institutional logo and landing page link settings, and stated a primary colour default of
`#e77f11` where `theme.ini` actually has `#707070`. Rewritten from the current `theme.ini`
rather than patched.

Added a note that `asset/css/style.css` is generated but committed and must be rebuilt when
Sass changes — the two had drifted apart, which is why the previous PR carried ~1200 lines
of unrelated CSS.

## Worth a look before merging

**A licence inconsistency inherited from upstream, left as is.** `asset/sass/style.scss`
says *"GNU General Public License v2 or later"* while `LICENSE` is the GPLv3 text and
`package.json` declares `GPL-3.0`. Both files came from upstream's initial commits. This is
legally coherent — "or later" permits distribution under v3 — and the README now explains
it rather than silently picking one. Changing the headers is a decision for the project,
not for a docs PR.

**Two version numbers disagree**, also left alone: `config/theme.ini` says `0.3.0`,
`package.json` and the Sass header say `1.0.7`. Omeka reads `theme.ini`. Not touched here
since it is not a documentation problem.

**The README is in English**, matching the existing README, the code comments and the
commit history. Say the word if it should be Spanish, or bilingual, given the audience.

All external links verified to return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
